### PR TITLE
Fixed PotionMerchant Error When Buying

### DIFF
--- a/public/assets/script/game/Game.js
+++ b/public/assets/script/game/Game.js
@@ -179,7 +179,7 @@ class Game {
             appendToDisplay(message);
             this.player.gainPotion();
             this.score -= this.potionPrice;
-            this.runStatsUpdate();
+            this.runStatsUpdate(true);
         }
     }
 }


### PR DESCRIPTION
Buying now wont throw an error for undefined potion button.